### PR TITLE
Code examples for episode 053 & 054

### DIFF
--- a/sample_code/ep053/README.md
+++ b/sample_code/ep053/README.md
@@ -1,0 +1,23 @@
+# [web security: what is a csrf exploit? (intermediate)](https://youtu.be/MXZhe0KduyE)
+
+Today I cover a topic which came up on stream recently: what is CSRF / XSRF and why should I care?  I show a demo application which has this problem as well as a real world example that I exploited.
+
+## Setup commands
+
+```bash
+virtualenv venv
+
+. venv/bin/activate
+
+pip install Flask Flask-WTF
+```
+
+## Interactive examples
+
+### Bash
+
+```bash
+python app.py
+
+firefox index.html &
+```

--- a/sample_code/ep053/rev01/app.py
+++ b/sample_code/ep053/rev01/app.py
@@ -1,0 +1,31 @@
+import flask
+
+
+app = flask.Flask(__name__)
+
+
+@app.route('/target', methods=['POST'])
+def target():
+    return 'the missiles were fired'
+
+
+@app.route('/')
+def index():
+    return '''\
+<!doctype html>
+<html>
+    <body>
+        <form action="/target" method="post">
+            <input type="submit" value="fire the missiles">
+        </form>
+    </body>
+</html>
+'''
+
+
+def main():
+    app.run(port=9002)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/sample_code/ep053/rev01/index.html
+++ b/sample_code/ep053/rev01/index.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<html>
+    <body>
+        <form action="http://127.0.0.1:9002/target" method="post">
+            <input type="submit" value="fire someone else's missiles">
+        </form>
+    </body>
+</html>

--- a/sample_code/ep053/rev02/index.html
+++ b/sample_code/ep053/rev02/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+    <body>
+        <form id="form1" action="http://127.0.0.1:9002/target" method="post">
+            <input type="submit" value="fire someone else's missiles">
+        </form>
+        <script>
+            document.getElementById('form1').submit()
+        </script>
+    </body>
+</html>

--- a/sample_code/ep053/rev03/index.html
+++ b/sample_code/ep053/rev03/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+    <body>
+        <iframe name="t1"></iframe>
+        <form
+            id="form1"
+            action="http://127.0.0.1:9002/target"
+            method="post"
+            target="t1"
+        >
+            <input type="submit" value="fire someone else's missiles">
+        </form>
+
+        <script>
+            document.getElementById('form1').submit()
+        </script>
+    </body>
+</html>

--- a/sample_code/ep053/rev04/index.html
+++ b/sample_code/ep053/rev04/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+    <body>
+        <iframe name="t1" width=1 height=1 style="visibility: hidden;"></iframe>
+        <form
+            id="form1"
+            action="http://127.0.0.1:9002/target"
+            method="post"
+            target="t1"
+            style="visibility: hidden;"
+        >
+            <input type="submit" value="fire someone else's missiles">
+        </form>
+
+        <script>
+            document.getElementById('form1').submit()
+        </script>
+    </body>
+</html>

--- a/sample_code/ep053/rev05/app.py
+++ b/sample_code/ep053/rev05/app.py
@@ -1,0 +1,36 @@
+import flask
+from flask_wtf.csrf import CSRFProtect
+
+
+app = flask.Flask(__name__)
+csrf = CSRFProtect(app)
+
+
+@app.route('/target', methods=['POST'])
+def target():
+    return 'the missiles were fired'
+
+
+@app.route('/')
+def index():
+    return flask.render_template_string('''\
+<!doctype html>
+<html>
+    <body>
+        <form action="/target" method="post">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <input type="submit" value="fire the missiles">
+        </form>
+    </body>
+</html>
+''')
+
+
+def main():
+    app.config.from_pyfile('config.py')
+    csrf.init_app(app)
+    app.run(port=9002)
+
+
+if __name__ == '__main__':
+    exit(main())

--- a/sample_code/ep053/rev05/config.py
+++ b/sample_code/ep053/rev05/config.py
@@ -1,0 +1,2 @@
+SECRET_KEY = 'secret_random_string'
+WTF_CSRF_SECRET_KEY = 'secret_random_string2'

--- a/sample_code/ep053/rev05/index.html
+++ b/sample_code/ep053/rev05/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+    <body>
+        <form action="http://127.0.0.1:9002/target" method="post">
+            Request should fail:
+            <input type="submit" value="fire someone else's missiles">
+        </form>
+    </body>
+</html>

--- a/sample_code/ep054/README.md
+++ b/sample_code/ep054/README.md
@@ -1,0 +1,39 @@
+# [python: functools.lru\_cache (beginner - intermediate)](https://youtu.be/K0Q5twtYxWY)
+
+Today I explain functools.lru_cache as well as a few ways that you might use it in your programs!
+
+## Interactive examples
+
+### Python
+
+```python
+square(2)
+square(2)
+
+square(2)
+square(2)
+
+square(2)
+square(3)
+square(4)
+square(3)
+square(2)
+
+square(5)
+square(3)
+square(2)
+square(4)
+
+get_thing()
+get_thing()
+
+square.__wrapped__
+square.__wrapped__(2)
+square.__wrapped__(2)
+```
+
+### Bash
+
+```bash
+python -i t.py
+```

--- a/sample_code/ep054/rev01/t.py
+++ b/sample_code/ep054/rev01/t.py
@@ -1,0 +1,7 @@
+import functools
+
+
+# @functools.lru_cache
+def square(x: float) -> float:
+    print(f'running: {x}')
+    return x * x

--- a/sample_code/ep054/rev02/t.py
+++ b/sample_code/ep054/rev02/t.py
@@ -1,0 +1,7 @@
+import functools
+
+
+@functools.lru_cache
+def square(x: float) -> float:
+    print(f'running: {x}')
+    return x * x

--- a/sample_code/ep054/rev03/t.py
+++ b/sample_code/ep054/rev03/t.py
@@ -1,0 +1,14 @@
+import functools
+
+
+@functools.lru_cache(maxsize=3)
+def square(x: float) -> float:
+    print(f'running: {x}')
+    return x * x
+
+
+@functools.lru_cache(maxsize=1)
+def get_thing() -> int:
+    # pretend this is expensive
+    print('expensive')
+    return 42


### PR DESCRIPTION
I extended the CSRF token example by adding the relevant `Flask-WTF` code snippets (checkout revision 5) in order to show the contrast between unprotected and CSRF protected endpoint. If you don't like the additional code, I can remove it.