### PR TITLE
Code examples for episode 139 & 140

### DIFF
--- a/sample_code/ep139/README.md
+++ b/sample_code/ep139/README.md
@@ -1,0 +1,11 @@
+# [with + context managers (part2: the easy way) (intermediate)](https://youtu.be/ucGpcA9r4hU)
+
+Today we continue the discussion about context managers and the with statement in python but with the much much easier way of writing them!
+
+## Interactive examples
+
+### Bash
+
+```bash
+python t2.py
+```

--- a/sample_code/ep139/rev01/t2.py
+++ b/sample_code/ep139/rev01/t2.py
@@ -1,0 +1,25 @@
+import contextlib
+from typing import Generator, Tuple
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@contextlib.contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+with my_ctx() as (x1, x2):
+    print('inside')
+    print(f'{x1=} {x2=}')

--- a/sample_code/ep139/rev02/t2.py
+++ b/sample_code/ep139/rev02/t2.py
@@ -1,0 +1,27 @@
+import contextlib
+from typing import Generator, Tuple
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@contextlib.contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise RuntimeError('wat')

--- a/sample_code/ep139/rev03/t2.py
+++ b/sample_code/ep139/rev03/t2.py
@@ -1,0 +1,27 @@
+import contextlib
+from typing import Generator, Tuple
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@contextlib.contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise FooError('wat')

--- a/sample_code/ep140/README.md
+++ b/sample_code/ep140/README.md
@@ -1,0 +1,12 @@
+# [how @contextmanager works (with/contexts part 3) (advanced)](https://youtu.be/nr_q2y0qxFg)
+
+Today I talk about how @contextlib.contextmanager works
+
+## Interactive examples
+
+### Bash
+
+```bash
+python t3.py
+python3.6 t3.py
+```

--- a/sample_code/ep140/rev01/t3.py
+++ b/sample_code/ep140/rev01/t3.py
@@ -1,0 +1,81 @@
+from types import TracebackType
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+
+TRet = TypeVar('TRet')
+
+
+class _MyContextManager(Generic[TRet]):
+    def __init__(self, gen: Generator[TRet, None, None]) -> None:
+        self.gen = gen
+
+    def __enter__(self) -> TRet:
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError('generator did not yield')
+
+    def __exit__(
+            self,
+            tp: Optional[Type[BaseException]],
+            inst: Optional[BaseException],
+            tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if tp is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return None
+            else:
+                raise RuntimeError('generator did not stop')
+        else:
+            try:
+                self.gen.throw(tp, inst, tb)
+            except StopIteration as e:
+                if inst is e:
+                    return False
+                else:
+                    return True
+            except BaseException as e:
+                if inst is e:
+                    return False
+                else:
+                    raise
+
+
+def my_contextmanager(
+    func: Callable[..., Generator[TRet, None, None]],
+) -> Callable[..., ContextManager[TRet]]:
+    def my_contextmanager_callable(*args, **kwargs) -> ContextManager[TRet]:
+        return _MyContextManager(func(*args, **kwargs))
+    return my_contextmanager_callable
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@my_contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+with my_ctx() as (x1, x2):
+    print('inside')
+    print(f'{x1=} {x2=}')

--- a/sample_code/ep140/rev02/t3.py
+++ b/sample_code/ep140/rev02/t3.py
@@ -1,0 +1,83 @@
+from types import TracebackType
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+
+TRet = TypeVar('TRet')
+
+
+class _MyContextManager(Generic[TRet]):
+    def __init__(self, gen: Generator[TRet, None, None]) -> None:
+        self.gen = gen
+
+    def __enter__(self) -> TRet:
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError('generator did not yield')
+
+    def __exit__(
+            self,
+            tp: Optional[Type[BaseException]],
+            inst: Optional[BaseException],
+            tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if tp is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return None
+            else:
+                raise RuntimeError('generator did not stop')
+        else:
+            try:
+                self.gen.throw(tp, inst, tb)
+            except StopIteration as e:
+                if inst is e:
+                    return False
+                else:
+                    return True
+            except BaseException as e:
+                if inst is e:
+                    return False
+                else:
+                    raise
+
+
+def my_contextmanager(
+    func: Callable[..., Generator[TRet, None, None]],
+) -> Callable[..., ContextManager[TRet]]:
+    def my_contextmanager_callable(*args, **kwargs) -> ContextManager[TRet]:
+        return _MyContextManager(func(*args, **kwargs))
+    return my_contextmanager_callable
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@my_contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise FooError('wat')

--- a/sample_code/ep140/rev03/t3.py
+++ b/sample_code/ep140/rev03/t3.py
@@ -1,0 +1,83 @@
+from types import TracebackType
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+
+TRet = TypeVar('TRet')
+
+
+class _MyContextManager(Generic[TRet]):
+    def __init__(self, gen: Generator[TRet, None, None]) -> None:
+        self.gen = gen
+
+    def __enter__(self) -> TRet:
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError('generator did not yield')
+
+    def __exit__(
+            self,
+            tp: Optional[Type[BaseException]],
+            inst: Optional[BaseException],
+            tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if tp is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return None
+            else:
+                raise RuntimeError('generator did not stop')
+        else:
+            try:
+                self.gen.throw(tp, inst, tb)
+            except StopIteration as e:
+                if inst is e:
+                    return False
+                else:
+                    return True
+            except BaseException as e:
+                if inst is e:
+                    return False
+                else:
+                    raise
+
+
+def my_contextmanager(
+    func: Callable[..., Generator[TRet, None, None]],
+) -> Callable[..., ContextManager[TRet]]:
+    def my_contextmanager_callable(*args, **kwargs) -> ContextManager[TRet]:
+        return _MyContextManager(func(*args, **kwargs))
+    return my_contextmanager_callable
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@my_contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing {inst=}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing {inst=}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise StopIteration('wat')

--- a/sample_code/ep140/rev04/t3.py
+++ b/sample_code/ep140/rev04/t3.py
@@ -1,0 +1,83 @@
+from types import TracebackType
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+
+TRet = TypeVar('TRet')
+
+
+class _MyContextManager(Generic[TRet]):
+    def __init__(self, gen: Generator[TRet, None, None]) -> None:
+        self.gen = gen
+
+    def __enter__(self) -> TRet:
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError('generator did not yield')
+
+    def __exit__(
+            self,
+            tp: Optional[Type[BaseException]],
+            inst: Optional[BaseException],
+            tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if tp is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return None
+            else:
+                raise RuntimeError('generator did not stop')
+        else:
+            try:
+                self.gen.throw(tp, inst, tb)
+            except StopIteration as e:
+                if inst is e:
+                    return False
+                else:
+                    return True
+            except BaseException as e:
+                if inst is e:
+                    return False
+                else:
+                    raise
+
+
+def my_contextmanager(
+    func: Callable[..., Generator[TRet, None, None]],
+) -> Callable[..., ContextManager[TRet]]:
+    def my_contextmanager_callable(*args, **kwargs) -> ContextManager[TRet]:
+        return _MyContextManager(func(*args, **kwargs))
+    return my_contextmanager_callable
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@my_contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing inst={inst!r}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing inst={inst!r}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise StopIteration('wat')

--- a/sample_code/ep140/rev05/t3.py
+++ b/sample_code/ep140/rev05/t3.py
@@ -1,0 +1,83 @@
+from types import TracebackType
+from typing import Callable
+from typing import ContextManager
+from typing import Generator
+from typing import Generic
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
+
+
+TRet = TypeVar('TRet')
+
+
+class _MyContextManager(Generic[TRet]):
+    def __init__(self, gen: Generator[TRet, None, None]) -> None:
+        self.gen = gen
+
+    def __enter__(self) -> TRet:
+        try:
+            return next(self.gen)
+        except StopIteration:
+            raise RuntimeError('generator did not yield')
+
+    def __exit__(
+            self,
+            tp: Optional[Type[BaseException]],
+            inst: Optional[BaseException],
+            tb: Optional[TracebackType],
+    ) -> Optional[bool]:
+        if tp is None:
+            try:
+                next(self.gen)
+            except StopIteration:
+                return None
+            else:
+                raise RuntimeError('generator did not stop')
+        else:
+            try:
+                self.gen.throw(tp, inst, tb)
+            except StopIteration as e:
+                if inst is e:
+                    return False
+                else:
+                    return True
+            except BaseException as e:
+                if inst is e:
+                    return False
+                else:
+                    raise
+
+
+def my_contextmanager(
+    func: Callable[..., Generator[TRet, None, None]],
+) -> Callable[..., ContextManager[TRet]]:
+    def my_contextmanager_callable(*args, **kwargs) -> ContextManager[TRet]:
+        return _MyContextManager(func(*args, **kwargs))
+    return my_contextmanager_callable
+
+
+class FooError(RuntimeError):
+    pass
+
+
+@my_contextmanager
+def my_ctx() -> Generator[Tuple[int, int], None, None]:
+    print('before')
+    try:
+        yield (42, 99)
+        print('after')
+    except FooError as inst:
+        print(f'suppressing inst={inst!r}')
+        return True
+    except BaseException as inst:
+        print(f'not suppressing inst={inst!r}')
+        raise
+
+
+ctx = my_ctx()
+print('before ctx')
+with ctx:
+    print('boom')
+    raise RuntimeError('hello')


### PR DESCRIPTION
Very nice series about context managers.
I have one question -- is there a particular reason why you didn't mention the `finally` part for the generator-based context manager?

I think that this is a really important aspect, because the mechanism behind `__exit__` is to run some cleanup or other procedure *after* (despite the fact that exception was raised for example). And the `finally` clause allows for that behavior to happen.
There is an example in the [python docs for contextlib.contextmanager](https://docs.python.org/3/library/contextlib.html#contextlib.contextmanager).

Maybe you didn't include it in order to reduce the complexity, but I guess that you can add one additional video to this series about the `finally` case or? :)
