### PR TITLE
Code examples for episode 143 & 144

### DIFF
--- a/sample_code/ep143/README.md
+++ b/sample_code/ep143/README.md
@@ -1,0 +1,43 @@
+# [easy fake objects with python's SimpleNamespace (beginner - intermediate)](https://youtu.be/8XvyHj8ndg8)
+
+Today I talk about a bit of a hidden gem in python: the SimpleNamespace class!  I also demo a few usecases for testing (where I find it to be the most useful)
+
+## Interactive examples
+
+### Python
+
+```python
+from types import SimpleNamespace
+import types
+
+types.TracebackType
+SimpleNamespace()
+SimpleNamespace(a='asdf', b=2, c=123.123)
+obj = SimpleNamespace(a='asdf', b=2, c=123.123)
+obj.a
+obj.b
+obj.c
+obj.d = 123
+obj
+
+class NS:
+    pass
+
+NS.a = 123
+NS
+
+class NS:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+    def __repr__(self):
+        attrs = ', '.join(f'{k}={v!r}' for k, v in self.__dict__.items())
+        return f'{type(self).__name__}({attrs})'
+
+NS(a='1', b='2')
+```
+
+### Bash
+
+```bash
+python t.py
+```

--- a/sample_code/ep143/rev01/t.py
+++ b/sample_code/ep143/rev01/t.py
@@ -1,0 +1,22 @@
+import subprocess
+import types
+
+import pytest
+
+
+@pytest.fixture
+def git_dir(tmpdir):
+    d = tmpdir.join('git')
+    subprocess.check_call(('git', 'init', str(d)))
+    commit_cmd = (
+        'git', '-C', f'{str(d)}', 'commit', '--allow-empty', '-m', 'init',
+    )
+    subprocess.check_call(commit_cmd)
+    rev_cmd = ('git', 'rev-parse', 'HEAD')
+    rev = subprocess.check_output(rev_cmd).strip().decode()
+
+    yield types.SimpleNamespace(directory=d, rev=rev)
+
+
+def test(git_dir):
+    ...

--- a/sample_code/ep144/README.md
+++ b/sample_code/ep144/README.md
@@ -1,0 +1,28 @@
+# [what is a git tag? (beginner - intermediate)](https://youtu.be/34CQxHXzD4w)
+
+Today I talk about git tags (lightweight and not) and how they differ from branches
+
+## Setup commands
+
+```bash
+git clone git@github.com:asottile/astpretty
+# git clone https://github.com/asottile/astpretty
+cd astpretty
+```
+
+## Interactive examples
+
+### Bash
+
+```bash
+git log --oneline --decorate --graph
+git tag test
+git log --oneline --decorate --graph
+git tag test2 <commit_hash>
+git tag test3 <commit_hash> -m 'tag test3'
+git log --oneline --decorate --graph
+git show test3
+git show test2
+git tag --sign test5
+git show test5
+```


### PR DESCRIPTION
The temp git dir example, somehow messes up with the `explains` repo, when I run it :D
My guess is: since there is already initialized git repo, it skips the `git init <tmp_dir>` step (at least under Windows), which is so weird.
I had to `git reset --soft ...` in order to remove the bunch of `init` commits that it created in the working branch.