### PR TITLE
Install the proper distutils package

### DIFF
--- a/sample_code/ep293/README.md
+++ b/sample_code/ep293/README.md
@@ -28,7 +28,6 @@ which pip3.10
 rm -rf /venv/
 which pip3.10
 ls /usr/local/bin/
-
 exit
 
 docker build -f Dockerfile.ensurepip -t base-ensurepip .

--- a/sample_code/ep293/rev01/Dockerfile.debian
+++ b/sample_code/ep293/rev01/Dockerfile.debian
@@ -7,6 +7,6 @@ RUN : \
     && add-apt-repository ppa:deadsnakes \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         python3.10 \
-        python3-distutils \
+        python3.10-distutils \
         python3-pip \
     && rm -rf /var/lib/apt/lists/*

--- a/sample_code/ep293/rev01/Dockerfile.get-pip
+++ b/sample_code/ep293/rev01/Dockerfile.get-pip
@@ -8,7 +8,7 @@ RUN : \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         curl \
         python3.10 \
-        python3-distutils \
+        python3.10-distutils \
         python3-pip \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Small fix for the container images that require `distutils` -- I was testing the weird bug with `html5lib` and the default python packages and forgot to revert the changes.