### PR TITLE
Bash examples for episode 448

### DIFF
--- a/sample_code/ep448/README.md
+++ b/sample_code/ep448/README.md
@@ -1,0 +1,22 @@
+# [docker: fast CI rebuilds with --cache-from (intermediate)](https://youtu.be/77j6JFBTmTc)
+
+Today I show how to speed up docker builds by using `--cache-from` (and why it's necessary at all!)
+
+## Interactive examples
+
+### Bash
+
+```bash
+docker images
+# docker pull ghcr.io/deadsnakes/focal
+
+git clone git@github.com:deadsnakes/runbooks
+cd runbooks/
+ls
+
+ls dockerfiles/Dockerfile.focal
+docker build -t img - < dockerfiles/Dockerfile.focal
+
+docker history --no-trunc ghcr.io/deadsnakes/focal
+docker build --cache-from ghcr.io/deadsnakes/focal -t img - < dockerfiles/Dockerfile.focal
+```


### PR DESCRIPTION
Sadly this example is not reproducible anymore -- it always rebuilds the image from scratch instead of using the cache.

I saw that only the `ubuntu:focal` image ID in the video differs from the one that I pull, so maybe the `ghcr.io/deadsnakes/focal` image itself uses older focal layer and that invalidates the caching for the following layers.
But anyways, I just wanted to let you know.

PS: When I try to pull the image by digest, the docker registry returns 500 error 😂
`docker pull ubuntu@sha256:53df61775e8856a464ca52d4cd9eabbf4eb3ceedbde5afecc57e417e7b7155d5`