### PR TITLE
Fix linting errors with python3.11 for episode 433

### DIFF
--- a/sample_code/ep433/rev01/t.py
+++ b/sample_code/ep433/rev01/t.py
@@ -4,4 +4,5 @@ from typing import TypeVarTuple
 Ts = TypeVarTuple('Ts')
 
 
-class C(Generic[*Ts]): ...
+class C(Generic[*Ts]):
+    ...

--- a/sample_code/ep433/rev03/t.py
+++ b/sample_code/ep433/rev03/t.py
@@ -1,7 +1,6 @@
 from typing import Generic
 from typing import TypeVarTuple
 from typing import TypeVar
-from typing import Unpack
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')

--- a/sample_code/ep433/rev04/t.py
+++ b/sample_code/ep433/rev04/t.py
@@ -1,7 +1,6 @@
 from typing import Generic
 from typing import TypeVarTuple
 from typing import TypeVar
-from typing import Unpack
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')

--- a/sample_code/ep433/rev05/t.py
+++ b/sample_code/ep433/rev05/t.py
@@ -2,7 +2,6 @@ from typing import TypeAlias
 from typing import Generic
 from typing import TypeVarTuple
 from typing import TypeVar
-from typing import Unpack
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')

--- a/sample_code/ep433/rev06/t.py
+++ b/sample_code/ep433/rev06/t.py
@@ -2,7 +2,6 @@ from typing import TypeAlias
 from typing import Generic
 from typing import TypeVarTuple
 from typing import TypeVar
-from typing import Unpack
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')

--- a/sample_code/ep433/rev07/t.py
+++ b/sample_code/ep433/rev07/t.py
@@ -2,7 +2,6 @@ from typing import TypeAlias
 from typing import Generic
 from typing import TypeVarTuple
 from typing import TypeVar
-from typing import Unpack
 
 T = TypeVar('T')
 Ts = TypeVarTuple('Ts')

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,11 @@ per-file-ignores =
     */ep061/*/t*.py:F821,F822
     */ep069/rev03/startup.py:E702
     */ep076/rev02/t.py:F821
-    */ep093/rev01/decorator_expr.py:E999
     */ep104/*/t.py:F821
     */ep115/rev01/t.py:F821
     */ep117/rev02/t.py:F821
     */ep133/*/t.py:W605
     */ep136/*/t.py:E402
-    */ep138/rev01/t.py:E999
     */ep146/*/t.py:F821
     */ep147/*/t.py:F821
     */ep169/rev01/t.py:F841
@@ -31,7 +29,7 @@ per-file-ignores =
     */ep197/*/t.py:E731,F821,F823,F841
     */ep234/rev02/t.py:F401
     */ep247/rev03/t2.py:E701
-    */ep250/*/t.py:E211,E999,F821
+    */ep250/*/t.py:E211,F821
     */ep283/rev02/t.py:E999
     */ep288/rev01/mypkg/__init__.py:F401
     */ep289/*/t.py:E122,E203,E211,E902,E999
@@ -45,10 +43,8 @@ per-file-ignores =
     */ep407/rev0*/a/main.py:E402
     */ep418/rev0*/t.py:F821
     */ep430/rev0*/t.py:F821
-    */ep433/rev0*/t.py:E999
+    */ep433/rev0*/t.py:F821
     */ep434/rev05/t.py:F821
-    */ep434/rev06/t.py:E999
     */ep434/rev08/typing.py:F821
-    */ep434/rev09/typing.py:E999
     */ep439/*/t.py:F821
     */ep496/*/t.py:F401


### PR DESCRIPTION
I was wondering why the F821 error about `reveal_type` was not an issue in earlier python versions.
And it seems that ignoring the E999 SyntaxError, actually masks the other remaining issues, which makes sense because the assumption is that the syntax is already broken for that file and the linter bailed out early.
But it was still interesting to me, why this was the case.